### PR TITLE
Atualização da paleta de cores das regras/força da senha e correção do script que relaciona a porcentagem à cor da barra

### DIFF
--- a/assets-src/sass/4-components/_c-create-account.scss
+++ b/assets-src/sass/4-components/_c-create-account.scss
@@ -294,19 +294,19 @@
 
         &.fraco {
             &::-webkit-progress-value {
-                background: red;    
+                background: #D2381B;    
             }
         }
 
         &.medio {
             &::-webkit-progress-value {
-                background: yellow;   
+                background: #FFCA3A;   
             }
         }
 
         &.forte {
             &::-webkit-progress-value {
-                background: green;    
+                background: #559931;    
             }
         }
     }

--- a/components/create-account/script.js
+++ b/components/create-account/script.js
@@ -119,14 +119,14 @@ app.component('create-account', {
                     currentPercent = currentPercent + percentToAdd;
                 }
 
-                let strongness = currentPercent.toFixed(0)
+                let strongness = currentPercent.toFixed(0);
                 if (strongness >= 0 && strongness <= 40) {
                     this.strongnessClass = 'fraco';
                 }
-                if (strongness >= 40 && strongness <= 90) {
+                if (strongness > 40 && strongness <= 80) {
                     this.strongnessClass = 'medio';
                 }
-                if (strongness >= 90 && strongness <= 100) {
+                if (strongness > 80 && strongness <= 100) {
                     this.strongnessClass = 'forte';
                 }
 

--- a/components/password-strongness/script.js
+++ b/components/password-strongness/script.js
@@ -121,7 +121,7 @@ app.component('password-strongness', {
                     currentPercent = currentPercent + percentToAdd;
                 }
 
-                return currentPercent.toFixed(0)
+                return currentPercent.toFixed(0);
             } else {
                 return 0;
             }
@@ -129,9 +129,9 @@ app.component('password-strongness', {
         },
 
         strongnessClass() {
-            if (this.strongness <= 40) {
+            if (this.strongness() <= 40) {
                 return 'fraco';
-            } else if (this.strongness <= 85) {
+            } else if (this.strongness() <= 80) {
                 return 'medio';
             } else {
                 return 'forte';

--- a/components/password-strongness/template.php
+++ b/components/password-strongness/template.php
@@ -17,7 +17,7 @@ use MapasCulturais\i;
 <div v-if="getErrors()" class="password-rules">
     <?= i::__('A senha deve conter:') ?><br>
     <div class="password-errors" v-for="error in getErrors()">
-        <div v-if="error.error" style="color:red;"><mc-icon name="close"></mc-icon> <span>{{error.message}}</span></div>
-        <div v-else style="color:green;"><mc-icon name="check-no-circle"></mc-icon> <span>{{error.message}}</span></div>
+        <div v-if="error.error" style="color:#D2381B;"><mc-icon name="close"></mc-icon> <span>{{error.message}}</span></div>
+        <div v-else style="color:#559931;"><mc-icon name="check-no-circle"></mc-icon> <span>{{error.message}}</span></div>
     </div>
 </div>


### PR DESCRIPTION
As cores foram atualizadas conforme foi requisitado na descrição da task. Agora tanto as regras para criação da senha como a barra de força da senha obedecem ao protótipo do Figma. Também foi corrigido a classe strongnessClass que antes sempre retornava "forte" pois havia erro quanto a referenciação do método. A relação porcentagem-cor da barra também foi corrigida conforme pedido.

[Issue RedeMapas/mapas#48](https://github.com/RedeMapas/mapas/issues/48#issue-2331189431)